### PR TITLE
Helm chart aware for release-aware

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,28 @@
+name: 'Release-aware server Docker image create & push'
+
+on:
+  push:
+    branches: [ master, helm-charts ]
+    paths:
+    - 'server/*'
+    - '.github/workflows/*'
+  pull_request:
+    branches: [ master ]
+    paths:
+    - 'server/*'
+    - '.github/workflows/*'
+jobs:
+
+  build-server-image:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: |
+        cd ./server
+        docker build . --file Dockerfile --tag sdpequinor/release-aware-api:latest
+        echo ${{ secrets.DOCKERHUB_PAT }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+        docker push sdpequinor/release-aware-api:latest
+        docker logout

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 server/vendor/
 server.env
+.vscode

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -73,8 +73,31 @@ class App extends React.Component {
             });
     }
 
+    refetchHelmData() {
+        axios
+            .get('/api/helmreleases')
+            .then(response => {
+                this.setState({
+                    isLoaded: true,
+                    releases: response.data,
+                    error: null,
+                });
+            })
+            // Note: it's important to handle errors here
+            // instead of a catch() block so that we don't swallow
+            // exceptions from actual bugs in components.
+            .catch(error => {
+                this.setState({
+                    isLoaded: true,
+                    error,
+                    lastSuccessfulFetch: new Date(),
+                });
+            });
+    }
+
     componentDidMount() {
         this.refetchData();
+        this.refetchHelmData();
         this.interval = setInterval(() => this.refetchData(), 100000);
     }
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -53,36 +53,17 @@ class App extends React.Component {
 
     refetchData() {
         axios
-            .get('/api/releases')
-            .then(response => {
-                this.setState({
-                    isLoaded: true,
-                    releases: response.data,
-                    error: null,
-                });
-            })
-            // Note: it's important to handle errors here
-            // instead of a catch() block so that we don't swallow
-            // exceptions from actual bugs in components.
-            .catch(error => {
-                this.setState({
-                    isLoaded: true,
-                    error,
-                    lastSuccessfulFetch: new Date(),
-                });
-            });
-    }
-
-    refetchHelmData() {
-        axios
-            .get('/api/helmreleases')
-            .then(response => {
-                this.setState({
-                    isLoaded: true,
-                    releases: response.data,
-                    error: null,
-                });
-            })
+            .all([
+                axios.get("/api/releases"),
+                axios.get("/api/helmreleases")
+            ])
+          .then(axios.spread((...responses) => {
+            this.setState({ 
+                isLoaded: true,
+                releases: responses[0].data.concat(responses[1].data),
+                error: null,
+             })
+          }))
             // Note: it's important to handle errors here
             // instead of a catch() block so that we don't swallow
             // exceptions from actual bugs in components.
@@ -97,7 +78,6 @@ class App extends React.Component {
 
     componentDidMount() {
         this.refetchData();
-        this.refetchHelmData();
         this.interval = setInterval(() => this.refetchData(), 100000);
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   server:
-    image: sdpequinor/release-aware-api:latest
+    image: sdpequinor/release-aware-api:1.7
     restart: unless-stopped
     command: /scripts/run-local-server.sh
     build:
@@ -57,13 +57,13 @@ services:
         eslint/eslint,
         webpack/webpack
   client:
-    image: sdpequinor/release-aware-web:latest
+    image: sdpequinor/release-aware-web:1.7
     restart: unless-stopped
     build:
       context:  ./client/
       dockerfile: Dockerfile
     ports:
-      - 80:3001
+      - 3001:3001
     volumes:
       - ./client/src:/code/src
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,11 @@ services:
         facebook/jest,
         eslint/eslint,
         webpack/webpack
+      HELM_REPOS: |
+        gitlab/gitlab,
+        fluxcd/flux,
+        jetstack/cert-manager,
+        stable/oauth2-proxy
   client:
     image: sdpequinor/release-aware-web:1.7
     restart: unless-stopped
@@ -63,7 +68,7 @@ services:
       context:  ./client/
       dockerfile: Dockerfile
     ports:
-      - 80:3001
+      - 3001:3001
     volumes:
       - ./client/src:/code/src
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,11 @@ services:
         facebook/jest,
         eslint/eslint,
         webpack/webpack
+      HELM_REPOS: |
+        gitlab/gitlab,
+        stable/grafana,
+        stable/oauth-proxy,
+        stable/sealed-secrets
   client:
     image: sdpequinor/release-aware-web:1.7
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   server:
-    image: sdpequinor/release-aware-api:1.7
+    image: sdpequinor/release-aware-api:latest
     restart: unless-stopped
     command: /scripts/run-local-server.sh
     build:
@@ -56,11 +56,6 @@ services:
         facebook/jest,
         eslint/eslint,
         webpack/webpack
-      HELM_REPOS: |
-        gitlab/gitlab,
-        stable/grafana,
-        stable/oauth-proxy,
-        stable/sealed-secrets
   client:
     image: sdpequinor/release-aware-web:1.7
     restart: unless-stopped
@@ -68,7 +63,7 @@ services:
       context:  ./client/
       dockerfile: Dockerfile
     ports:
-      - 3001:3001
+      - 80:3001
     volumes:
       - ./client/src:/code/src
     environment:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,18 +1,14 @@
 FROM golang:1.12.5
 
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-
 # install required debian packages
 # add any package that is required after `build-essential`, end the line with \
 RUN apt-get update && apt-get install -y \
     build-essential \
 && rm -rf /var/lib/apt/lists/*
 
-# install glide,  gin and delve
+# install glide and gin
 RUN go get github.com/Masterminds/glide
 RUN go get github.com/codegangsta/gin
-RUN go get github.com/go-delve/delve/cmd/dlv
 
 # setup the working directory
 WORKDIR /go/src/app
@@ -31,5 +27,5 @@ ADD src src
 # build the source
 RUN go build src/main.go
 
-# Expose 2345 for Delve debugger
-EXPOSE 2345
+# command to be executed on running the container
+CMD ["./main"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,14 +1,18 @@
 FROM golang:1.12.5
 
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
 # install required debian packages
 # add any package that is required after `build-essential`, end the line with \
 RUN apt-get update && apt-get install -y \
     build-essential \
 && rm -rf /var/lib/apt/lists/*
 
-# install glide and gin
+# install glide,  gin and delve
 RUN go get github.com/Masterminds/glide
 RUN go get github.com/codegangsta/gin
+RUN go get github.com/go-delve/delve/cmd/dlv
 
 # setup the working directory
 WORKDIR /go/src/app
@@ -27,5 +31,5 @@ ADD src src
 # build the source
 RUN go build src/main.go
 
-# command to be executed on running the container
-CMD ["./main"]
+# Expose 2345 for Delve debugger
+EXPOSE 2345

--- a/server/src/main.go
+++ b/server/src/main.go
@@ -204,15 +204,19 @@ func getHelmhubRelease(repositoryName string) (HelmRelease, error) {
 	if !resp.Ok {
 		return HelmRelease{}, errors.New(string(resp.Bytes()))
 	}
-	return HelmRelease{}, errors.New("Could not find any helmrelease for " + repositoryName)
+	release := parseHelmhubRelease(resp.String())
+
+	return release, errors.New("Could not find any helmrelease for " + repositoryName)
 }
 
 func parseHelmhubRelease (resp string) HelmRelease {
 	var helmRelease HelmRelease
 
-	helmRelease.Name = gjson.Get(resp, ".data.attributes.repo.name"+"/"+".data.attributes.name").String()
+	repoName := gjson.Get(resp, ".data.attributes.repo.name").String()
+	name := gjson.Get(resp, ".data.attributes.name").String()
+	helmRelease.Name = repoName + "/" + name
 	helmRelease.Id = gjson.Get(resp, "data.relationships.latestChartVersion.data.version").String()
-	helmRelease.HtmlUrl = gjson.Get(resp, "hub.helm.sh/"+".data.relationships.latestChartVersion.links.self").String()
+	helmRelease.HtmlUrl = "hub.helm.sh/" + gjson.Get(resp, ".data.relationships.latestChartVersion.links.self").String()
 	helmRelease.PublishedAt = gjson.Get(resp, "data.relationships.latestChartVersion.data.created").Time()
 
 	return helmRelease


### PR DESCRIPTION
One known issue:

The frontend makes rendering of /api/releases and /api/helmreleases compete, currently only one of them are displayed at a time. We want to combine this into one.

There is also probably some duplicate / poor code due to lacking experience with React and Golang.